### PR TITLE
Update io-package. json - fix E162 an E204

### DIFF
--- a/io-package.json
+++ b/io-package.json
@@ -29,19 +29,6 @@
         "uk": "підтримка нового модуля реле 12 каналів",
         "zh-cn": "支持新的12个频道中继模块"
       },
-      "1.4.0": {
-        "en": "support for new 12 channel relay module",
-        "de": "unterstützung für neues 12-kanal-relaismodul",
-        "ru": "поддержка нового 12-канального ретрансляционного модуля",
-        "pt": "suporte para novo módulo de relé de 12 canais",
-        "nl": "ondersteuning voor nieuwe 12 kanaal relais module",
-        "fr": "prise en charge du nouveau module relais 12 canaux",
-        "it": "supporto per il nuovo modulo relè a 12 canali",
-        "es": "soporte para nuevo módulo de relé de 12 canales",
-        "pl": "obsługa nowego modułu przekaźnika 12 kanałów",
-        "uk": "підтримка нового модуля реле 12 каналів",
-        "zh-cn": "支持新的12个频道中继模块"
-      },
       "1.3.0": {
         "en": "support for new analog inputs (0-10V or 4-20mA)",
         "de": "unterstützung für neue analoge Eingänge (0-10V oder 4-20mA)",
@@ -144,7 +131,7 @@
     "materialize": true,
     "dependencies": [
       {
-        "js-controller": ">=2.0.0"
+        "js-controller": ">=5.0.19"
       }
     ],
     "globalDependencies": [


### PR DESCRIPTION
Fixes for reposchecker issues.
Please verify and merge / retest

❗ [E162] js-controller 2.0.0 listed as dependency but 4.0.24 is required as minimum, 5.0.19 is recommended. Please update dependency at [io-package.json](https://github.com/hausbus/ioBroker.hausbus_de/blob/master/io-package.json).

Config ahs been changed to require admin 5.0.19 which is the previous stable release. Older js-controllers are no longer recommended. If you really need you may change to require 4.0.24. But please ensure that the adapter has been tested with tis old controller.
 
❗ [E204] Version "1.4.0" listed at common.news at [io-package.json](https://github.com/hausbus/ioBroker.hausbus_de/blob/master/io-package.json) does not exist at [NPM](https://www.npmjs.com/package/iobroker.hausbus_de). Please remove from news section.

News entry has been removed as news entries without existing npm releases will cause unexpected errors whenever users try to install them