### PR TITLE
Update package.json - fix for E026

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,6 +18,9 @@
     "type": "git",
     "url": "https://github.com/hausbus/ioBroker.hausbus_de.git"
   },
+  "engines": {
+    "node": ">=18"
+  },
   "dependencies": {
     "@iobroker/adapter-core": "^2.6.12",
     "ip": "^1.1.8"


### PR DESCRIPTION
Fixes for reposchecker issues.
Please verify and merge / retest

❗ [E026] "{'engines': {'node'>='16'}}" is required at [package.json](https://github.com/hausbus/ioBroker.hausbus_de/blob/master/package.json), "{'engines':{'node'>='18'}}" is recommened

Adapter requires node 18 now. (Please encrease at least minor version for next release)